### PR TITLE
c-api: added public routines for adding user-defined intrinsics

### DIFF
--- a/src/bootstrap/libnany/CMakeLists.txt
+++ b/src/bootstrap/libnany/CMakeLists.txt
@@ -288,6 +288,7 @@ addsrc(
 	"c-api/queueservice.cpp"
 	"c-api/report.cpp"
 	"c-api/sandbox.cpp"
+	"c-api/intrinsics.cpp"
 	"c-api/source.cpp"
 	"c-api/utilities.cpp"
 	"c-api/validator.cpp"

--- a/src/bootstrap/libnany/c-api/intrinsics.cpp
+++ b/src/bootstrap/libnany/c-api/intrinsics.cpp
@@ -1,0 +1,52 @@
+#include <yuni/yuni.h>
+#include "nany/nany.h"
+#include "details/context/context.h"
+#include <limits.h>
+
+using namespace Yuni;
+
+
+
+
+extern "C" nybool_t
+nany_add_intrinsic(nycontext_t* ctx, const char* name, uint32_t flags, void* callback, nytype_t ret, ...)
+{
+	try
+	{
+		if (ctx and ctx->build.internal)
+		{
+			auto& context = *(reinterpret_cast<Nany::Context*>(ctx->build.internal));
+
+			AnyString intrname{name};
+			va_list argp;
+			va_start(argp, ret);
+			bool success = context.intrinsics.add(intrname, flags, callback, ret, argp);
+			va_end(argp);
+			return (success) ? nytrue : nyfalse;
+		}
+	}
+	catch (...) {}
+	return nyfalse;
+}
+
+
+extern "C" nybool_t
+nany_add_intrinsic_n(nycontext_t* ctx, const char* name, size_t length, uint32_t flags, void* callback, nytype_t ret, ...)
+{
+	try
+	{
+		if (ctx and ctx->build.internal)
+		{
+			auto& context = *(reinterpret_cast<Nany::Context*>(ctx->build.internal));
+
+			AnyString intrname{name, length};
+			va_list argp;
+			va_start(argp, ret);
+			bool success = context.intrinsics.add(intrname, flags, callback, ret, argp);
+			va_end(argp);
+			return (success) ? nytrue : nyfalse;
+		}
+	}
+	catch (...) {}
+	return nyfalse;
+}

--- a/src/bootstrap/libnany/details/context/context-build.cpp
+++ b/src/bootstrap/libnany/details/context/context-build.cpp
@@ -52,7 +52,7 @@ namespace Nany
 	inline std::unique_ptr<BuildInfoContext> Context::doBuildWL(Logs::Report report, int64_t& duration)
 	{
 		pBuildInfo.reset(nullptr); // release some memory
-		auto buildinfoptr = std::make_unique<BuildInfoContext>(pIntrinsics);
+		auto buildinfoptr = std::make_unique<BuildInfoContext>(intrinsics);
 		auto& buildinfo = *(buildinfoptr.get());
 		// the result will succeed by default, and will be reverted to false as soon as an error occurs
 		buildinfo.success = true;
@@ -80,8 +80,8 @@ namespace Nany
 		Nany::Sema::Metadata::initialize(); // TODO remove those methods
 		Nany::ASTHelper::initialize();
 
-		if (pIntrinsics.empty())
-			pIntrinsics.registerStdCore();
+		if (intrinsics.empty())
+			intrinsics.registerStdCore();
 
 		// preparing the queue service if not already present
 		if (!pQueueservice)

--- a/src/bootstrap/libnany/details/context/context.cpp
+++ b/src/bootstrap/libnany/details/context/context.cpp
@@ -21,7 +21,7 @@ namespace Nany
 
 	Context::Context(nycontext_t& context, const Context& rhs)
 		: usercontext(context)
-		, pIntrinsics(rhs.pIntrinsics)
+		, intrinsics(rhs.intrinsics)
 		, pQueueservice(rhs.pQueueservice)
 	{
 		// import targets

--- a/src/bootstrap/libnany/details/context/context.h
+++ b/src/bootstrap/libnany/details/context/context.h
@@ -57,6 +57,9 @@ namespace Nany
 		//! Attached context
 		nycontext_t& usercontext;
 
+		//! All intrinsics
+		IntrinsicTable intrinsics;
+
 
 	private:
 		//! Copy constructor (import a template)
@@ -68,9 +71,6 @@ namespace Nany
 		CTarget::Ptr pDefaultTarget;
 		//! All other targets
 		std::unordered_map<AnyString, CTarget::Ptr> pTargets;
-
-		//! All intrinsics
-		IntrinsicTable pIntrinsics;
 
 		//! Queue service
 		Yuni::Job::QueueService::Ptr pQueueservice;

--- a/src/bootstrap/libnany/details/intrinsic/intrinsic-table.cpp
+++ b/src/bootstrap/libnany/details/intrinsic/intrinsic-table.cpp
@@ -11,5 +11,44 @@ namespace Nany
 	}
 
 
+	bool IntrinsicTable::add(const AnyString& name, uint32_t flags, void* callback, nytype_t ret, va_list argp)
+	{
+		if (YUNI_UNLIKELY(name.empty() or (0 == pByNames.count(name))))
+			return false;
+		if (YUNI_UNLIKELY(nullptr == callback))
+			return false;
+
+		auto* intrinsic = new Intrinsic(name, callback);
+		intrinsic->rettype = ret;
+		intrinsic->flags   = flags;
+
+		uint32_t count = 0;
+		do
+		{
+			int i = va_arg(argp, int);
+			if (i == 0)
+				break;
+
+			if (count >= Config::maxPushedParameters or i >= static_cast<int>(nyt_count))
+			{
+				delete intrinsic;
+				return false;
+			}
+
+			intrinsic->params[count] = static_cast<nytype_t>(i);
+			++count;
+		}
+		while(true);
+
+		intrinsic->paramcount = count;
+
+
+		pIntrinsics.emplace_back(intrinsic);
+		pByNames.insert(std::make_pair(AnyString{intrinsic->name}, std::ref(*(intrinsic))));
+		return true;
+	}
+
+
+
 
 } // namespace Nany

--- a/src/bootstrap/libnany/details/intrinsic/intrinsic-table.h
+++ b/src/bootstrap/libnany/details/intrinsic/intrinsic-table.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 #include <memory>
+#include <stdarg.h>
 
 
 
@@ -25,6 +26,8 @@ namespace Nany
 		** \brief Add a new intrinsic
 		*/
 		template<class T> bool add(const AnyString& name, T callback);
+
+		bool add(const AnyString& name, uint32_t flags, void* callback, nytype_t ret, va_list argp);
 
 		/*!
 		** \brief Get if an intrinsic exists

--- a/src/bootstrap/libnany/details/intrinsic/intrinsic.h
+++ b/src/bootstrap/libnany/details/intrinsic/intrinsic.h
@@ -3,6 +3,7 @@
 #include <yuni/string.h>
 #include <yuni/core/smartptr/intrusive.h>
 #include "nany/nany.h"
+#include "libnany-config.h"
 
 
 
@@ -10,6 +11,9 @@
 namespace Nany
 {
 
+	/*!
+	** \brief Definition of a single user-defined intrinsic
+	*/
 	class Intrinsic final
 		: public Yuni::IIntrusiveSmartPtr<Intrinsic, false, Yuni::Policy::SingleThreaded>
 		, Yuni::NonCopyable<Intrinsic>
@@ -22,32 +26,30 @@ namespace Nany
 
 
 	public:
-		static constexpr uint maxParameterCount = 12;
-
-
-	public:
-		Intrinsic(const AnyString& name)
-			: name(name)
+		Intrinsic(const AnyString& name, void* callback)
+			: callback(callback)
+			, name(name)
 		{}
 
 		Intrinsic(const Intrinsic&) = default;
 
 
 	public:
+		//! C-Callback
+		const void* callback;
+
 		//! name of the intrinsic
 		const Yuni::ShortString64 name;
 
-		//! C-Callback
-		void* callback = nullptr;
-
 		//! The return type
 		nytype_t rettype = nyt_void;
-
 		//! The total number of parameters
-		uint paramcount = 0;
+		uint32_t paramcount = 0;
 		//! All parameter types
-		std::array<nytype_t, maxParameterCount> params;
+		std::array<nytype_t, Config::maxPushedParameters> params;
 
+		//! Flags
+		uint32_t flags = static_cast<uint32_t>(nyintr_flag_default);
 
 	}; // class Intrinsic
 

--- a/src/bootstrap/libnany/nany/nany.h
+++ b/src/bootstrap/libnany/nany/nany.h
@@ -242,24 +242,17 @@ typedef enum /* nyerr_level_t */
 } nyerr_level_t;
 
 
-/*! Intrinsic definition */
-typedef struct nyintrinsic_t
+
+/*! Flags for intrinsic callbacks */
+typedef enum
 {
-	/*! name of the intrinsic (!! myname)*/
-	const char* name;
-	/*! return type */
-	nytype_t rettype;
+	nyintr_flag_default          = (1 << 0),
+	/*! The parameters will be used from another thread */
+	nyintr_flag_params_in_thread = (1 << 1),
+	/*! The callback will never return */
+	nyintr_flag_never_return     = (1 << 2),
 
-	/*! total number of parameters */
-	uint32_t paramcount;
-	/*! list of parameter types */
-	const nytype_t* parameters;
-	/*! C callback */
-	void* callback;
-}
-nyintrinsic_t;
-
-
+} nyintrinsic_flag_t;
 
 
 
@@ -476,6 +469,39 @@ NY_EXPORT nybool_t nany_report_print_stderr(const nyreport_t* report);
 
 /*! Print information about the nany library */
 NY_EXPORT nybool_t nany_report_add_compiler_headerinfo(nyreport_t* report);
+/*@}*/
+
+
+
+
+/*! \name Intrinsics */
+/*@{*/
+/*!
+** \briefe Register a new intrinsic function
+**
+** \param name Name of the intrinsic (ex: 'myprogram.hello.world')
+** \param flags List of flags (see nyintrinsic_flag_t). nyintr_flag_default or 0 if unsure
+** \param callback C callback at runtime
+** \param ret The return type
+** \param ret... List of parameter types, followed by 'nyt_void'
+** \return nytrue if the operation succeeded
+*/
+NY_EXPORT nybool_t
+nany_add_intrinsic(nycontext_t*, const char* name, uint32_t flags, void* callback, nytype_t ret, ...);
+
+/*!
+** \briefe Register a new intrinsic function
+**
+** \param name Name of the intrinsic (ex: 'myprogram.hello.world')
+** \param length Length of the intrinsic name
+** \param flags List of flags (see nyintrinsic_flag_t). nyintr_flag_default or 0 if unsure
+** \param callback C callback at runtime
+** \param ret The return type
+** \param ret... List of parameter types, followed by 'nyt_void'
+** \return nytrue if the operation succeeded
+*/
+NY_EXPORT nybool_t
+nany_add_intrinsic_n(nycontext_t*, const char* name, size_t length, uint32_t flags, void* callback, nytype_t ret, ...);
 /*@}*/
 
 


### PR DESCRIPTION
The routines `nany_add_intrinsic` and `nany_add_intrinsic_n` are able to
inject an user-defined callback accessible from the Nany code (via the
special directive `!!`).
- However, the Nany VM is yet unable to call them natively (the `dyncall`
  library will be added for that)
- the flags are currently unused but will be in the future
- see #14
